### PR TITLE
Introduce \abrv, avoid clash with \aa

### DIFF
--- a/mathsemantics-abbreviations.sty
+++ b/mathsemantics-abbreviations.sty
@@ -3,51 +3,56 @@
 % Resolve the dependencies of this package
 \RequirePackage{mathsemantics-commons}
 
+\NewDocumentCommand{\abrv}{ >{\SplitList{}} m }{%
+  \ProcessList{#1}{\abrvf}%
+  \xspace%
+}
+\NewDocumentCommand{\abrvf}{m}{#1.\,}
 % Define some English abbreviations
-\let\aa\undefined \newcommand{\aa}{a.a.\xspace}
-\newcommand{\ale}{a.e.\xspace}
-\let\cf\undefined \newcommand{\cf}{cf.\xspace}
-\newcommand{\eg}{e.\,g.\xspace}
-\newcommand{\Eg}{E.\,g.\xspace}
-\let\ie\undefined \newcommand{\ie}{i.\,e.\xspace}
-\newcommand{\Ie}{I.\,e.\xspace}
-\newcommand{\iid}{i.\,i.\,d.\xspace}
-\let\st\undefined \newcommand{\st}{s.\,t.\xspace}  % WileyNJD-v2.cls (loads soul.sty)
-\newcommand{\wolog}{w.l.o.g.\xspace} % \wlog is a LaTeX core command which writes to the .log file
-\newcommand{\wrt}{w.r.t.\xspace}
+\newcommand{\ala}{\abrv{aa}}
+\newcommand{\ale}{\abrv{ae}}
+\providecommand*{\cf}{cf.\xspace}
+\newcommand{\eg}{\abrv{eg}}
+\newcommand{\Eg}{\abrv{Eg}}
+\providecommand*{\ie}{\abrv{ie}}
+\newcommand{\Ie}{\abrv{Ie}}
+\newcommand{\iid}{\abrv{iid}}
+\newcommand{\suth}{\abrv{st}}
+\newcommand{\wolog}{\abrv{wlog}} % \wlog is a LaTeX core command which writes to the .log file
+\newcommand{\wrt}{\abrv{wrt}}
+\newcommand{\spd}{\abrv{spd}}
 
 % Define some German abbreviations
 \newcommand{\bspw}{bspw.\xspace}
 \newcommand{\bzgl}{bzgl.\xspace}
 \newcommand{\bzw}{bzw.\xspace}
-\newcommand{\dah}{d.\,h.\xspace}
-\newcommand{\Dah}{D.\,h.\xspace}
+\newcommand{\dah}{\abrv{dh}}
+\newcommand{\Dah}{\abrv{Dh}}
 \newcommand{\etc}{etc.\xspace}
 \newcommand{\evtl}{evtl.\xspace}
 \newcommand{\Evtl}{Evtl.\xspace}
-\newcommand{\fue}{f.\,ü.\xspace}
-\newcommand{\fs}{f.\,s.\xspace}
-\newcommand{\iA}{i.\,A.\xspace}
-\newcommand{\IA}{I.\,A.\xspace}
-\newcommand{\idR}{i.\,d.\,R.\xspace}
-\newcommand{\IdR}{I.\,d.\,R.\xspace}
-\newcommand{\iW}{i.\,W.\xspace}
-\newcommand{\IW}{I.\,W.\xspace}
-\newcommand{\mE}{m.\,E.\xspace}
-\newcommand{\oBdA}{o.\,B.\,d.\,A.\xspace}
-\newcommand{\OBdA}{O.\,B.\,d.\,A.\xspace}
-\let\og\undefined \newcommand{\og}{o.\,g.\xspace}  % cedram.cls
-\newcommand{\oae}{o.\,ä.\xspace}
-\newcommand{\pa}{p.\,a.\xspace}
-\newcommand{\spd}{s.\,p.\,d.\xspace}
-\let\so\undefined \newcommand{\so}{s.\,t.\xspace}  % WileyNJD-v2.cls (loads soul.sty)
-\newcommand{\ua}{u.\,a.\xspace}
-\newcommand{\ug}{u.\,g.\xspace}
+\newcommand{\fue}{\abrv{f{\"u}}}
+\newcommand{\fs}{\abrv{fs}}
+\newcommand{\iA}{\abrv{iA}}
+\newcommand{\IA}{\abrv{IA}}
+\newcommand{\idR}{\abrv{idR}}
+\newcommand{\IdR}{\abrv{IdR}}
+\newcommand{\iW}{\abrv{iW}}
+\newcommand{\IW}{\abrv{IW}}
+\newcommand{\mE}{\abrv{mE}}
+\newcommand{\oBdA}{\abrv{oBdA}}
+\newcommand{\OBdA}{\abrv{ObdA}}
+\newcommand{\oge}{\abrv{og}}  % cedram.cls
+\newcommand{\oae}{\abrv{o{\"a}}}
+\newcommand{\pa}{\abrv{pa}}
+\newcommand{\sio}{\abrv{so}}  % WileyNJD-v2.cls (loads soul.sty)
+\newcommand{\ua}{\abrv{ua}}
+\newcommand{\ug}{\abrv{ug}}
 \newcommand{\usw}{usw.\xspace}
-\newcommand{\Ua}{U.\,a.\xspace}
-\newcommand{\uU}{u.\,U.\xspace}
-\newcommand{\UnU}{U.\,U.\xspace}
+\newcommand{\Ua}{\abrv{Ua}}
+\newcommand{\uU}{\abrv{uU}}
+\newcommand{\UnU}{\abrv{UU}}
 \newcommand{\vgl}{vgl.\xspace}
-\newcommand{\zB}{z.\,B.\xspace}
-\newcommand{\ZB}{Z.\,B.\xspace}
-\newcommand{\zHd}{z.\,Hd.\xspace}
+\newcommand{\zB}{\abrv{zB}}
+\newcommand{\ZB}{\abrv{ZB}}
+\newcommand{\zHd}{\abrv{z{Hd}}}

--- a/mathsemantics-abbreviations.sty
+++ b/mathsemantics-abbreviations.sty
@@ -42,10 +42,10 @@
 \newcommand{\mE}{\abrv{mE}}
 \newcommand{\oBdA}{\abrv{oBdA}}
 \newcommand{\OBdA}{\abrv{ObdA}}
-\newcommand{\oge}{\abrv{og}}  % cedram.cls
+\newcommand{\oge}{\abrv{og}}
 \newcommand{\oae}{\abrv{o{\"a}}}
 \newcommand{\pa}{\abrv{pa}}
-\newcommand{\sio}{\abrv{so}}  % WileyNJD-v2.cls (loads soul.sty)
+\newcommand{\sio}{\abrv{so}}
 \newcommand{\ua}{\abrv{ua}}
 \newcommand{\ug}{\abrv{ug}}
 \newcommand{\usw}{usw.\xspace}

--- a/mathsemantics-abbreviations.sty
+++ b/mathsemantics-abbreviations.sty
@@ -1,4 +1,4 @@
-\ProvidesPackage{mathsemantics-abbreviations}[2022/05/06]
+\ProvidesPackage{mathsemantics-abbreviations}[2022/05/10]
 
 % Resolve the dependencies of this package
 \RequirePackage{mathsemantics-commons}

--- a/mathsemantics-commons.sty
+++ b/mathsemantics-commons.sty
@@ -1,4 +1,4 @@
-\ProvidesPackage{mathsemantics-commons}[2022/05/06]
+\ProvidesPackage{mathsemantics-commons}[2022/05/10]
 
 % Packages which allow control flow
 \RequirePackage{ifthen}

--- a/mathsemantics-documentation.tex
+++ b/mathsemantics-documentation.tex
@@ -169,17 +169,26 @@
     \end{commandlist}
 
     \section{Abbreviations}
+        Abbreviations and their spacing might be diifcult to genannt
+        \begin{commandlist}
+            \item[abrv] write the letters provided as an abbreviation
+            \par\codeExample{\abrv{ie}}
+            \par\codeExample{\abrv{wlog}} % chktex 1
+        \end{commandlist}
+        And we introduce a few of them specifically also a few that are not following this scheme.
         \label{sec:abbreviations}
         \subsection{English}
         \begin{commandlist}
-            \item[aa] almost all \codeExample{\aa}
+            \item[ala] almost all \codeExample{\ala}
             \item[ale] almost everywhere \codeExample{\ale}
+            \item[cf] conferatur (compare (to)) \codeExample{\cf}
             \item[eg] exempli gratia (for example) \codeExample{\eg}
+            \item[Eg] Exempli gratia (for example, at beginning of a sentence) \codeExample{\Eg}
             \item[etc] et cetera (and so on) \codeExample{\etc}
             \item[ie] id est (id est) \codeExample{\ie}
             \item[iid] independent and identically distributed \codeExample{\iid}
             \item[spd] symmetric positive definite \codeExample{\spd}
-            \item[st] such that or subject to \codeExample{\st}
+            \item[suth] such that or subject to \codeExample{\suth}
             \item[wrt] with respect to \codeExample{\wrt}
         \end{commandlist}
         \subsection{German}
@@ -201,9 +210,9 @@
                 \item[mE] meines Erachtens \codeExample{\mE}
                 \item[oBdA] ohne Beschränkung der Allgemeinheit \codeExample{\oBdA}
                 \item[OBdA] ohne Beschränkung der Allgemeinheit (beginning of phrase) \par\codeExample{\OBdA}
-                \item[og] oben genannt \codeExample{\og}
+                \item[oge] oben genannt \codeExample{\oge}
                 \item[oae] oder ähnliche \codeExample{\oae}
-                \item[so] siehe oben \codeExample{\so}
+                \item[sio] siehe oben \codeExample{\sio}
                 \item[ua] unter anderem \codeExample{\ua}
                 \item[Ua] Unter anderem (beginning of phrase) \codeExample{\Ua}
                 \item[ug] unten genannt \codeExample{\ug}

--- a/mathsemantics-documentation.tex
+++ b/mathsemantics-documentation.tex
@@ -1,6 +1,6 @@
 \documentclass[english,a4paper,DIV=12,parskip=full,oneside]{scrartcl}
 \usepackage{mathsemantics-documentation-local}
-\date{\today, v\,1.0.0}
+\date{\today, v\,1.0.1}
 \author{%
     Ronny Bergmann\\[.25\baselineskip]%
     \small\href{mailto:ronny.bergmann@ntnu.no}{ronny.bergmann@ntnu.no}\\[.125\baselineskip]

--- a/mathsemantics-manifolds.sty
+++ b/mathsemantics-manifolds.sty
@@ -1,6 +1,6 @@
 % This LaTeX package provides numerous commands relevant to typesetting
 % material related to manifolds and differential geometry.
-\ProvidesPackage{mathsemantics-manifolds}[2022/05/06]
+\ProvidesPackage{mathsemantics-manifolds}[2022/05/10]
 
 % Resolve the dependencies of this package
 \RequirePackage{mathsemantics-semantic}

--- a/mathsemantics-names.sty
+++ b/mathsemantics-names.sty
@@ -1,4 +1,4 @@
-\ProvidesPackage{mathsemantics-names}[2022/05/06]
+\ProvidesPackage{mathsemantics-names}[2022/05/10]
 
 % Resolve the dependencies of this package
 \RequirePackage{mathsemantics-commons}

--- a/mathsemantics-optimization.sty
+++ b/mathsemantics-optimization.sty
@@ -1,6 +1,6 @@
 % This LaTeX package provides numerous commands relevant to typesetting
 % material related to manifolds and differential geometry.
-\ProvidesPackage{mathsemantics-optimization}[2022/05/06]
+\ProvidesPackage{mathsemantics-optimization}[2022/05/10]
 
 % Resolve the dependencies of this package
 \RequirePackage{mathsemantics-semantic}

--- a/mathsemantics-semantic.sty
+++ b/mathsemantics-semantic.sty
@@ -1,4 +1,4 @@
-\ProvidesPackage{mathsemantics-semantic}[2022/05/06]
+\ProvidesPackage{mathsemantics-semantic}[2022/05/10]
 
 % Resolve the dependencies of this package
 \RequirePackage{mathsemantics-commons}

--- a/mathsemantics-syntax.sty
+++ b/mathsemantics-syntax.sty
@@ -1,4 +1,4 @@
-\ProvidesPackage{mathsemantics-syntax}[2022/05/06]
+\ProvidesPackage{mathsemantics-syntax}[2022/05/10]
 \provideboolean{mathsemantics@syntax@shortbb}
 \setboolean{mathsemantics@syntax@shortbb}{false}% default: false
 \DeclareOption{shortbb}{%

--- a/mathsemantics.sty
+++ b/mathsemantics.sty
@@ -1,7 +1,7 @@
 %
 % mathsemantics.sty
 %
-\ProvidesPackage{mathsemantics}[2022/05/06 MathSemantics.sty v1.0.0]
+\ProvidesPackage{mathsemantics}[2022/05/10 MathSemantics.sty v1.0.1]
 \DeclareOption{shortbb}{%
     \PassOptionsToPackage{shortbb}{mathsemantics-syntax}
 }


### PR DESCRIPTION
This PR introduces a `\abrv` command to easily type abbreviations and uses this in out list of abbreviation.

Is also avoids several collisions with existing packages and for example with `\aa` (å), and hence should resolve #3.